### PR TITLE
Dependabot extensions: Bump all OpenTelemetry dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@
 name: Solution build
 
 on:
-  #push:
-  #  branches:
-  #    - main
-  #pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@
 name: Solution build
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  #push:
+  #  branches:
+  #    - main
+  #pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
         run: |
             echo Upgrade to OpenTelemetry ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
-            echo "opentelemetry_version=$(${{ github.event.pull_request.title }} | sed 's/.* //'") >> "$GITHUB_OUTPUT"
+            echo "opentelemetry_version=$("${{ github.event.pull_request.title }}" | sed 's/.* //'") >> "$GITHUB_OUTPUT"
             echo "Dependabots Bump OpenTelemetry to $opentelemetry_version detected"
 
   fix-opentelemetry-dependencies: 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       status: ${{ steps.check.conclusion }}
       opentelemetry_version: ${{ steps.check.outputs.opentelemetry_version }}
+      opentelemetry_library: ${{ steps.check.outputs.opentelemetry_library }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,26 +26,25 @@ jobs:
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
             echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
+            echo "opentelemetry_library=$(echo '${{ github.event.pull_request.title }}' | sed 's/.*Bump //' | cut -f1 -d' ')" >> "$GITHUB_OUTPUT"
             echo "Dependabots Bump OpenTelemetry detected"
 
   fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest
     needs: detect-opentelemetry-upgrades
     if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
-    env:
-        opentelemetry_version=${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
     steps:
       - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_ENV }}
-      - name: Force all OpenTelemetry libraries on all projects
+      - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
         run: |
-            echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
-            dotnet add package OpenTelemetry --version ${{ env.opentelemetry_version }}
-            dotnet add package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-            dotnet add package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            echo Upgrade to OpenTelemetry ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -25,6 +25,8 @@ jobs:
         run: echo Title is not helloworld
       - name: Extract branch name
         shell: bash
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: |
+            echo "${GITHUB_REF}" 
+            echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Print branch name
         run: echo The branch name ${{ env.branch }}

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -15,30 +15,29 @@ jobs:
   detect-opentelemetry-upgrades:
     outputs:
       status: ${{ steps.check.conclusion }}
+      opentelemetry_version: ${{ steps.check.outputs.opentelemetry_version }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      #- name: Print title of PR
-      #  run: echo The Title of your PR is ${{ github.event.pull_request.title }}
       - name: Dependabots Bump OpenTelemetry detected 
         id: check
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
             echo Dependabots Bump OpenTelemetry detected 
-            echo ${{ github.event.pull_request.title }} | sed 's/.* //' 
+            echo "opentelemetry_version=${{ github.event.pull_request.title }} | sed 's/.* //'" >> "$GITHUB_OUTPUT"
 
-  #fix-opentelemetry-dependencies: 
-  #  runs-on: ubuntu-latest
-  #  needs: detect-opentelemetry-upgrades
-  #  if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
-  #  steps:
-  #    - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
-  #      uses: actions/setup-dotnet@v3
-  #      with:
-  #        dotnet-version: ${{ env.DOTNET_ENV }}
-  #    - name: Force all OpenTelemetry libraries on all projects
-  #      run: echo Dependabots Bump OpenTelemetry detected 
+  fix-opentelemetry-dependencies: 
+    runs-on: ubuntu-latest
+    needs: detect-opentelemetry-upgrades
+    if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
+    steps:
+      #- name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
+      #  uses: actions/setup-dotnet@v3
+      #  with:
+      #    dotnet-version: ${{ env.DOTNET_ENV }}
+      - name: Force all OpenTelemetry libraries on all projects
+        run: echo Upgrade to ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened]
   workflow_dispatch:
 
 env:
@@ -41,10 +42,9 @@ jobs:
       - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
         run: |
             echo Upgrade to OpenTelemetry ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -20,9 +20,12 @@ jobs:
       - name: Check if PR is bump OpenTelemetry
         if: startsWith(${{ github.event.pull_request.title }}, ${{ env.FILTER }})
         run: echo TTitle is bump open telemetry
-      - name: Check if PR is bump OpenTelemetry
+      - name: Check if PR is not hellowolrd
         if: startsWith(${{ github.event.pull_request.title }}, 'helloworld')
         run: echo TTitle is not helloworld
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
       - name: Print branch name
-        run: echo The branch name ${{ github.ref }}
-      
+        run: echo The branch name ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -30,3 +30,7 @@ jobs:
             echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Print branch name
         run: echo The branch name ${{ env.branch }}
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  FILTER: 'Bump OpenTelemetry from'
+  PR_TITLE_FILTER: 'Bump OpenTelemetry from'
+  BRANCH_NAME_FILTER: 'task/opentelemetry-lib-update'
 
 jobs:
   opentelemetry-upgrades:
@@ -18,7 +19,7 @@ jobs:
       - name: Print title of PR
         run: echo The Title of your PR is ${{ github.event.pull_request.title }}
       - name: Check if PR is bump OpenTelemetry
-        if: ${{ startsWith(github.event.pull_request.title, env.FILTER) }} 
+        if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} 
         run: echo TTitle is bump open telemetry
       - name: Check if PR is not hellowolrd
         if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
@@ -29,3 +30,9 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+      - name: Check if branch is dependabots
+        if: ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
+        run: echo branch is dependabots
+      - name: Check if PR is not hellowolrd
+        if: ${{ startsWith(github.event.pull_request.head.ref, 'helloworld') }} 
+        run: echo branch is not helloworld

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
-            echo "opentelemetry_version=$("${{ github.event.pull_request.title }}" | sed 's/.* //'") >> "$GITHUB_OUTPUT"
+            echo "opentelemetry_version=$('${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
             echo "Dependabots Bump OpenTelemetry to $opentelemetry_version detected"
 
   fix-opentelemetry-dependencies: 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -25,7 +25,8 @@ jobs:
         run: echo TTitle is not helloworld
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        # echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - name: Print branch name
         run: echo The branch name ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -1,0 +1,14 @@
+name: OpenTelemetry upgrade
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  opentelemetry-upgrades:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -24,8 +24,8 @@ jobs:
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
-            echo Dependabots Bump OpenTelemetry detected 
-            echo "opentelemetry_version=${{ github.event.pull_request.title }} | sed 's/.* //'" >> "$GITHUB_OUTPUT"
+            echo "opentelemetry_version=$(${{ github.event.pull_request.title }} | sed 's/.* //'") >> "$GITHUB_OUTPUT"
+            echo "Dependabots Bump OpenTelemetry to $opentelemetry_version detected"
 
   fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -19,7 +19,6 @@ jobs:
       opentelemetry_library: ${{ steps.check.outputs.opentelemetry_library }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Dependabots Bump OpenTelemetry detected 
         id: check
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
@@ -34,6 +33,7 @@ jobs:
     needs: detect-opentelemetry-upgrades
     if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
     steps:
+      - uses: actions/checkout@v3
       - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened]
+  #pull_request:
+  #  types: [opened]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  #pull_request:
+  pull_request:
   #  types: [opened]
   workflow_dispatch:
 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -12,3 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Print title of PR
+        run: echo The Title of your PR is ${{ github.event.pull_request.title }}

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -12,16 +12,31 @@ env:
   BRANCH_NAME_FILTER: 'task/opentelemetry-lib-update'
 
 jobs:
-  opentelemetry-upgrades:
+  detect-opentelemetry-upgrades:
+    outputs:
+        status: ${{ steps.check.conclusion }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       #- name: Print title of PR
       #  run: echo The Title of your PR is ${{ github.event.pull_request.title }}
       - name: Dependabots Bump OpenTelemetry detected 
+        id: check
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
+        run: exit_with_success
+  fix-opentelemetry-dependencies: 
+    runs-on: ubuntu-latest
+    needs: detect-opentelemetry-upgrades
+    if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
+    steps:
+      - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_ENV }}
+      - name: Force all OpenTelemetry libraries on all projects
         run: echo Dependabots Bump OpenTelemetry detected 
+
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
       #  run: echo Title is not helloworld

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -22,11 +22,9 @@ jobs:
         run: echo TTitle is bump open telemetry
       - name: Check if PR is not hellowolrd
         if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
-        run: echo TTitle is not helloworld
+        run: echo Title is not helloworld
       - name: Extract branch name
         shell: bash
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        # echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Print branch name
-        run: echo The branch name ${{ steps.extract_branch.outputs.branch }}
+        run: echo The branch name ${{ env.branch }}

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -45,10 +45,25 @@ jobs:
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-      - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Api --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+      - name: Commit changes to PR
+        uses: stefanzweifel/git-auto-commit-action@v4.16.0
         with:
             commit_message: Fix all CSPROJ projects
-            commit_user_name: JM89
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -1,16 +1,12 @@
 name: OpenTelemetry upgrade
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-  #  types: [opened]
-  workflow_dispatch:
+    types: [opened, reopened]
 
 env:
   PR_TITLE_FILTER: 'Bump OpenTelemetry from'
-  BRANCH_NAME_FILTER: 'task/opentelemetry-lib-update'
+  BRANCH_NAME_FILTER: 'dependabot'
 
 jobs:
   detect-opentelemetry-upgrades:
@@ -46,26 +42,25 @@ jobs:
       - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
         run: |
             echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
-            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            #dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-            #dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            #dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            #dotnet add ./Worker/Worker.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-            #dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-            #dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            #dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package Flurl --version 3.0.7
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
       - name: Commit changes to PR
         uses: stefanzweifel/git-auto-commit-action@v4.16.0
         with:

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
             echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
-            echo "Dependabots Bump OpenTelemetry to ${{ steps.check.outputs.opentelemetry_version }}"
+            echo "Dependabots Bump OpenTelemetry to ${{ $GITHUB_OUTPUT }}"
 
   fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -13,60 +13,96 @@ env:
   BRANCH_NAME_FILTER: 'task/opentelemetry-lib-update'
 
 jobs:
-  detect-opentelemetry-upgrades:
-    outputs:
-      status: ${{ steps.check.conclusion }}
-      opentelemetry_version: ${{ steps.check.outputs.opentelemetry_version }}
-      opentelemetry_library: ${{ steps.check.outputs.opentelemetry_library }}
+  debug: 
     runs-on: ubuntu-latest
     steps:
-      #- name: Dump GitHub context
-      #  env:
-      #    GITHUB_CONTEXT: ${{ toJson(github) }}
-      - name: Dependabots Bump OpenTelemetry detected 
-        id: check
-        if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
-            ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
-        run: | 
-            echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
-            echo "opentelemetry_library=$(echo '${{ github.event.pull_request.title }}' | sed 's/.*Bump //' | cut -f1 -d' ')" >> "$GITHUB_OUTPUT"
-            echo "Dependabots Bump OpenTelemetry detected"
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+  force-trigger-ci:
+    # https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Force the execution of the main build
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+          workflow: Solution build
 
-  fix-opentelemetry-dependencies: 
-    runs-on: ubuntu-latest
-    needs: detect-opentelemetry-upgrades
-    if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.DOTNET_ENV }}
-      - name: Save library version
-        run: echo "opentelemetry_version=${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}" >> $GITHUB_ENV
-      - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
-        run: |
-            echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
-            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-      - name: Commit changes to PR
-        uses: stefanzweifel/git-auto-commit-action@v4.16.0
-        with:
-            commit_message: Fix all CSPROJ projects
+  #detect-opentelemetry-upgrades:
+  #  outputs:
+  #    status: ${{ steps.check.conclusion }}
+  #    opentelemetry_version: ${{ steps.check.outputs.opentelemetry_version }}
+  #    opentelemetry_library: ${{ steps.check.outputs.opentelemetry_library }}
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    #- name: Dump GitHub context
+  #    #  env:
+  #    #    GITHUB_CONTEXT: ${{ toJson(github) }}
+  #    - name: Dependabots Bump OpenTelemetry detected 
+  #      id: check
+  #      if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
+  #          ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
+  #      run: | 
+  #          echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
+  #          echo "opentelemetry_library=$(echo '${{ github.event.pull_request.title }}' | sed 's/.*Bump //' | cut -f1 -d' ')" >> "$GITHUB_OUTPUT"
+  #          echo "Dependabots Bump OpenTelemetry detected"
+
+  #fix-opentelemetry-dependencies: 
+  #  runs-on: ubuntu-latest
+  #  needs: detect-opentelemetry-upgrades
+  #  if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
+  #      uses: actions/setup-dotnet@v3
+  #      with:
+  #        dotnet-version: ${{ env.DOTNET_ENV }}
+  #    - name: Save library version
+  #      run: echo "opentelemetry_version=${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}" >> $GITHUB_ENV
+  #    - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
+  #      run: |
+  #          echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
+  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+  #    - name: Commit changes to PR
+  #      uses: stefanzweifel/git-auto-commit-action@v4.16.0
+  #      with:
+  #          commit_message: Fix all CSPROJ projects

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -48,6 +48,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
           workflow: Solution build
+          ref: ${{ github.event.pull_request.head.ref }}
 
   #detect-opentelemetry-upgrades:
   #  outputs:

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -23,13 +23,8 @@ jobs:
       - name: Check if PR is not hellowolrd
         if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
         run: echo Title is not helloworld
-      - name: Extract branch name
-        shell: bash
-        run: |
-            echo "${GITHUB_REF}" 
-            echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Print branch name
-        run: echo The branch name ${{ env.branch }}
+        run: echo The branch name ${{ github.event.pull_request.head.ref }}
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
-            echo "opentelemetry_version=$('${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
+            echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
             echo "Dependabots Bump OpenTelemetry to $opentelemetry_version detected"
 
   fix-opentelemetry-dependencies: 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Print title of PR
         run: echo The Title of your PR is ${{ github.event.pull_request.title }}
       - name: Check if PR is bump OpenTelemetry
-        if: startsWith(${{ github.event.pull_request.title }}, ${{ env.FILTER }})
+        if: ${{ startsWith(github.event.pull_request.title, env.FILTER) }} 
         run: echo TTitle is bump open telemetry
       - name: Check if PR is not hellowolrd
-        if: startsWith(${{ github.event.pull_request.title }}, 'helloworld')
+        if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
         run: echo TTitle is not helloworld
       - name: Extract branch name
         shell: bash

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -45,6 +45,10 @@ jobs:
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+      - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        with:
+            commit_message: Fix all CSPROJ projects
+            commit_user_name: JM89
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -25,19 +25,26 @@ jobs:
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
             echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
-            echo "Dependabots Bump OpenTelemetry to '${{ github.event.pull_request.title }}' | sed 's/.* //')"
+            echo "Dependabots Bump OpenTelemetry detected"
 
   fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest
     needs: detect-opentelemetry-upgrades
     if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
+    env:
+        opentelemetry_version=${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
     steps:
-      #- name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
-      #  uses: actions/setup-dotnet@v3
-      #  with:
-      #    dotnet-version: ${{ env.DOTNET_ENV }}
+      - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_ENV }}
       - name: Force all OpenTelemetry libraries on all projects
-        run: echo Upgrade to ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+        run: |
+            echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
+            dotnet add package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            dotnet add package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -13,104 +13,60 @@ env:
   BRANCH_NAME_FILTER: 'task/opentelemetry-lib-update'
 
 jobs:
-  debug: 
+  detect-opentelemetry-upgrades:
+    outputs:
+      status: ${{ steps.check.conclusion }}
+      opentelemetry_version: ${{ steps.check.outputs.opentelemetry_version }}
+      opentelemetry_library: ${{ steps.check.outputs.opentelemetry_library }}
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "$JOB_CONTEXT"
-      - name: Dump steps context
-        env:
-          STEPS_CONTEXT: ${{ toJson(steps) }}
-        run: echo "$STEPS_CONTEXT"
-      - name: Dump runner context
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-        run: echo "$RUNNER_CONTEXT"
-      - name: Dump strategy context
-        env:
-          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-        run: echo "$STRATEGY_CONTEXT"
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: echo "$MATRIX_CONTEXT"
-  force-trigger-ci:
-    # https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+      - name: Dependabots Bump OpenTelemetry detected 
+        id: check
+        if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
+            ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
+        run: | 
+            echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
+            echo "opentelemetry_library=$(echo '${{ github.event.pull_request.title }}' | sed 's/.*Bump //' | cut -f1 -d' ')" >> "$GITHUB_OUTPUT"
+            echo "Dependabots Bump OpenTelemetry detected"
+
+  fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest
+    needs: detect-opentelemetry-upgrades
+    if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
     steps:
-      - name: Force the execution of the main build
-        uses: benc-uk/workflow-dispatch@v1.2.2
+      - uses: actions/checkout@v3  
         with:
-          workflow: Solution build
-          ref: ${{ github.event.pull_request.head.ref }}
-      - name: Force PR check
-        uses: LouisBrunner/checks-action@v1.3.1
+          token: ${{ secrets.PAT }}
+      - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
+        uses: actions/setup-dotnet@v3
         with:
-            sha: ${{ github.sha }}
-            token: ${{ github.token }}
-            name: Solution build
-            status: in_progress
-
-  #detect-opentelemetry-upgrades:
-  #  outputs:
-  #    status: ${{ steps.check.conclusion }}
-  #    opentelemetry_version: ${{ steps.check.outputs.opentelemetry_version }}
-  #    opentelemetry_library: ${{ steps.check.outputs.opentelemetry_library }}
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    #- name: Dump GitHub context
-  #    #  env:
-  #    #    GITHUB_CONTEXT: ${{ toJson(github) }}
-  #    - name: Dependabots Bump OpenTelemetry detected 
-  #      id: check
-  #      if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
-  #          ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
-  #      run: | 
-  #          echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
-  #          echo "opentelemetry_library=$(echo '${{ github.event.pull_request.title }}' | sed 's/.*Bump //' | cut -f1 -d' ')" >> "$GITHUB_OUTPUT"
-  #          echo "Dependabots Bump OpenTelemetry detected"
-
-  #fix-opentelemetry-dependencies: 
-  #  runs-on: ubuntu-latest
-  #  needs: detect-opentelemetry-upgrades
-  #  if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
-  #      uses: actions/setup-dotnet@v3
-  #      with:
-  #        dotnet-version: ${{ env.DOTNET_ENV }}
-  #    - name: Save library version
-  #      run: echo "opentelemetry_version=${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}" >> $GITHUB_ENV
-  #    - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
-  #      run: |
-  #          echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
-  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
-  #          dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
-  #    - name: Commit changes to PR
-  #      uses: stefanzweifel/git-auto-commit-action@v4.16.0
-  #      with:
-  #          commit_message: Fix all CSPROJ projects
+          dotnet-version: ${{ env.DOTNET_ENV }}
+      - name: Save library version
+        run: echo "opentelemetry_version=${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}" >> $GITHUB_ENV
+      - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
+        run: |
+            echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
+            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            #dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            #dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            #dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            #dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            #dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            #dotnet add ./Worker/Worker.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            #dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            #dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            #dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package Flurl --version 3.0.7
+      - name: Commit changes to PR
+        uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        with:
+            commit_message: Fix all CSPROJ projects

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -49,6 +49,13 @@ jobs:
         with:
           workflow: Solution build
           ref: ${{ github.event.pull_request.head.ref }}
+      - name: Force PR check
+        uses: LouisBrunner/checks-action@v1.3.1
+        with:
+            sha: ${{ github.sha }}
+            token: ${{ github.token }}
+            name: Solution build
+            status: in_progress
 
   #detect-opentelemetry-upgrades:
   #  outputs:

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   detect-opentelemetry-upgrades:
     outputs:
-        status: ${{ steps.check.conclusion }}
+      status: ${{ steps.check.conclusion }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
         id: check
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
-        run: exit_with_success
+        run: echo Dependabots Bump OpenTelemetry detected 
   fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest
     needs: detect-opentelemetry-upgrades

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -16,23 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Print title of PR
-        run: echo The Title of your PR is ${{ github.event.pull_request.title }}
-      - name: Check if PR is bump OpenTelemetry
-        if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} 
-        run: echo TTitle is bump open telemetry
-      - name: Check if PR is not hellowolrd
-        if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
-        run: echo Title is not helloworld
-      - name: Print branch name
-        run: echo The branch name ${{ github.event.pull_request.head.ref }}
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Check if branch is dependabots
-        if: ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
-        run: echo branch is dependabots
-      - name: Check if PR is not hellowolrd
-        if: ${{ startsWith(github.event.pull_request.head.ref, 'helloworld') }} 
-        run: echo branch is not helloworld
+      #- name: Print title of PR
+      #  run: echo The Title of your PR is ${{ github.event.pull_request.title }}
+      - name: Dependabots Bump OpenTelemetry detected 
+        if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
+            ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
+        run: echo Dependabots Bump OpenTelemetry detected 
+      #- name: Check if PR is not hellowolrd
+      #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
+      #  run: echo Title is not helloworld
+      #- name: Print branch name
+      #  run: echo The branch name ${{ github.event.pull_request.head.ref }}
+      #- name: Dump GitHub context
+      #  env:
+      #    GITHUB_CONTEXT: ${{ toJson(github) }}
+      #  run: echo "$GITHUB_CONTEXT"
+      #- name: Check if branch is dependabots
+      #  if: ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
+      #  run: echo branch is dependabots
+      #- name: Check if PR is not hellowolrd
+      #  if: ${{ startsWith(github.event.pull_request.head.ref, 'helloworld') }} 
+      #  run: echo branch is not helloworld

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  FILTER: 'Bump OpenTelemetry from'
+
 jobs:
   opentelemetry-upgrades:
     runs-on: ubuntu-latest
@@ -14,3 +17,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Print title of PR
         run: echo The Title of your PR is ${{ github.event.pull_request.title }}
+      - name: Check if PR is bump OpenTelemetry
+        if: startsWith(${{ github.event.pull_request.title }}, ${{ env.FILTER }})
+        run: Title is bump open telemetry
+      - name: Check if PR is bump OpenTelemetry
+        if: startsWith(${{ github.event.pull_request.title }}, 'helloworld')
+        run: Title is not helloworld
+      - name: Print branch name
+        run: echo The branch name ${{ github.ref }}
+      

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -24,18 +24,21 @@ jobs:
         id: check
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
-        run: echo Dependabots Bump OpenTelemetry detected 
-  fix-opentelemetry-dependencies: 
-    runs-on: ubuntu-latest
-    needs: detect-opentelemetry-upgrades
-    if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
-    steps:
-      - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.DOTNET_ENV }}
-      - name: Force all OpenTelemetry libraries on all projects
-        run: echo Dependabots Bump OpenTelemetry detected 
+        run: | 
+            echo Dependabots Bump OpenTelemetry detected 
+            echo ${{ github.event.pull_request.title }} | sed 's/.* //' 
+
+  #fix-opentelemetry-dependencies: 
+  #  runs-on: ubuntu-latest
+  #  needs: detect-opentelemetry-upgrades
+  #  if: needs.detect-opentelemetry-upgrades.outputs.status == 'success'
+  #  steps:
+  #    - name: Setup .NET Core SDK ${{ env.DOTNET_ENV }}
+  #      uses: actions/setup-dotnet@v3
+  #      with:
+  #        dotnet-version: ${{ env.DOTNET_ENV }}
+  #    - name: Force all OpenTelemetry libraries on all projects
+  #      run: echo Dependabots Bump OpenTelemetry detected 
 
       #- name: Check if PR is not hellowolrd
       #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
             echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
             dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
             dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
             echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
-            echo "Dependabots Bump OpenTelemetry to $opentelemetry_version detected"
+            echo "Dependabots Bump OpenTelemetry to ${{ steps.check.outputs.opentelemetry_version }}"
 
   fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -19,10 +19,10 @@ jobs:
         run: echo The Title of your PR is ${{ github.event.pull_request.title }}
       - name: Check if PR is bump OpenTelemetry
         if: startsWith(${{ github.event.pull_request.title }}, ${{ env.FILTER }})
-        run: Title is bump open telemetry
+        run: echo TTitle is bump open telemetry
       - name: Check if PR is bump OpenTelemetry
         if: startsWith(${{ github.event.pull_request.title }}, 'helloworld')
-        run: Title is not helloworld
+        run: echo TTitle is not helloworld
       - name: Print branch name
         run: echo The branch name ${{ github.ref }}
       

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -20,6 +20,9 @@ jobs:
       opentelemetry_library: ${{ steps.check.outputs.opentelemetry_library }}
     runs-on: ubuntu-latest
     steps:
+      #- name: Dump GitHub context
+      #  env:
+      #    GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Dependabots Bump OpenTelemetry detected 
         id: check
         if: ${{ startsWith(github.event.pull_request.title, env.PR_TITLE_FILTER) }} && 
@@ -39,44 +42,30 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_ENV }}
+      - name: Save library version
+        run: echo "opentelemetry_version=${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}" >> $GITHUB_ENV
       - name: Force all ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_library }} libraries on all projects
         run: |
-            echo Upgrade to OpenTelemetry ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Api --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
-            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ needs.detect-opentelemetry-upgrades.outputs.opentelemetry_version }}
+            echo Upgrade to OpenTelemetry ${{ env.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./MyLambda/MyLambda.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.One/SampleApi.One.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Api --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./SampleApi.Two/SampleApi.Two.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
+            dotnet add ./Shared/Shared.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Console --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.OpenTelemetryProtocol --version ${{ env.opentelemetry_version }}
+            dotnet add ./Worker/Worker.csproj package OpenTelemetry.Exporter.Zipkin --version ${{ env.opentelemetry_version }}
       - name: Commit changes to PR
         uses: stefanzweifel/git-auto-commit-action@v4.16.0
         with:
             commit_message: Fix all CSPROJ projects
-
-      #- name: Check if PR is not hellowolrd
-      #  if: ${{ startsWith(github.event.pull_request.title, 'helloworld') }} 
-      #  run: echo Title is not helloworld
-      #- name: Print branch name
-      #  run: echo The branch name ${{ github.event.pull_request.head.ref }}
-      #- name: Dump GitHub context
-      #  env:
-      #    GITHUB_CONTEXT: ${{ toJson(github) }}
-      #  run: echo "$GITHUB_CONTEXT"
-      #- name: Check if branch is dependabots
-      #  if: ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
-      #  run: echo branch is dependabots
-      #- name: Check if PR is not hellowolrd
-      #  if: ${{ startsWith(github.event.pull_request.head.ref, 'helloworld') }} 
-      #  run: echo branch is not helloworld

--- a/.github/workflows/opentelemetry-upgrades.yml
+++ b/.github/workflows/opentelemetry-upgrades.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ startsWith(github.event.pull_request.head.ref, env.BRANCH_NAME_FILTER) }} 
         run: | 
             echo "opentelemetry_version=$(echo '${{ github.event.pull_request.title }}' | sed 's/.* //')" >> "$GITHUB_OUTPUT"
-            echo "Dependabots Bump OpenTelemetry to ${{ $GITHUB_OUTPUT }}"
+            echo "Dependabots Bump OpenTelemetry to '${{ github.event.pull_request.title }}' | sed 's/.* //')"
 
   fix-opentelemetry-dependencies: 
     runs-on: ubuntu-latest

--- a/SampleApi.One/SampleApi.One.csproj
+++ b/SampleApi.One/SampleApi.One.csproj
@@ -16,10 +16,10 @@
     <PackageReference Include="Flurl.Http" Version="3.2.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.3.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" />
     <PackageReference Include="Serilog" Version="2.12.0" />

--- a/SampleApi.Two/SampleApi.Two.csproj
+++ b/SampleApi.Two/SampleApi.Two.csproj
@@ -10,10 +10,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.3.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9" />

--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -7,9 +7,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9" />
   </ItemGroup>
 

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.84" />
-    <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="OpenTelemetry" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.4.0" />

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.84" />
+    <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="OpenTelemetry" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.4.0" />

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -9,9 +9,10 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.84" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="OpenTelemetry" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9" />
   </ItemGroup>
 


### PR DESCRIPTION
The OpenTelemetry main libraries and its dependencies crash when updated one at a time. 
Dependabot PRs for OpenTelemetry never built. 
This PR creates a GitHub Workflow to handle OpenTelemetry upgrades automatically. 

